### PR TITLE
Release Action - Match Updated MCP Registry Docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,11 +152,7 @@ jobs:
 
       - name: Install MCP Publisher
         run: |
-          ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
-          OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.1.0/mcp-publisher_1.1.0_${OS}_${ARCH}.tar.gz" | tar xz
-          chmod +x mcp-publisher
-          ./mcp-publisher --version
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
 
       - name: Login to MCP Registry
         run: ./mcp-publisher login github-oidc


### PR DESCRIPTION
- registry docs had wrong line to pull mcp registry executable
- corrected to match docs/ pull latest version rather than pinned version
